### PR TITLE
Add deltarpm to list of installed packages.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-yum install -q -y git python python-crypto python-devel python-lxml python-setuptools @development-tools libxml2-devel libxslt-devel libffi-devel
+yum install -q -y deltarpm git python python-crypto python-devel python-lxml python-setuptools @development-tools libxml2-devel libxslt-devel libffi-devel
 
 if [ ! -f /etc/udev/rules.d/80-net-setup-link.rules ]; then
     ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules


### PR DESCRIPTION
This saves time by using deltas instead of full RPMs when installing and
updating packages here.

Signed-off-by: Kyle Mestery mestery@noironetworks.com
